### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DRYResponder
 ============
 
-[![DRYResponder build status](https://travis-ci.org/appfoundry/DRYResponder.svg?branch=master)](https://travis-ci.org/appfoundry/DRYResponder)   [![Cocoapods Version](https://cocoapod-badges.herokuapp.com/v/DRYResponder/badge.png)](http://cocoadocs.org/docsets/DRYResponder/)
+[![DRYResponder build status](https://travis-ci.org/appfoundry/DRYResponder.svg?branch=master)](https://travis-ci.org/appfoundry/DRYResponder)   [![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/DRYResponder/badge.png)](http://cocoadocs.org/docsets/DRYResponder/)
 
 This project holds our very light-weight callhandle and responder framework for asynchronous communication, typically between an app and a backend system.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
